### PR TITLE
setupTestFrameworkScriptFile has been deprecated

### DIFF
--- a/tests/jest-rtl/jest.config.js
+++ b/tests/jest-rtl/jest.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  setupTestFrameworkScriptFile: './rtl.setup.js'
+  setupFilesAfterEnv: ['./rtl.setup.js']
 };


### PR DESCRIPTION
In [Jest 24](https://jestjs.io/docs/en/configuration#setupfilesafterenv-array), `setupTestFrameworkScriptFile` has been deprecated in favor of `setupFilesAfterEnv`.