### PR TITLE
Revert "refactor: replaced waitForElement by findByText (#51)"

### DIFF
--- a/tests/jest-rtl/local-state/test.js
+++ b/tests/jest-rtl/local-state/test.js
@@ -14,15 +14,15 @@ const renderComponent = ({ count }) =>
 
 it('renders initial count', async () => {
   // Render new instance in every test to prevent leaking state
-  const { findByText } = renderComponent({ count: 5 });
+  const { getByText } = renderComponent({ count: 5 });
 
-  expect(await findByText(/clicked 5 times/i))
+  await waitForElement(() => getByText(/clicked 5 times/i));
 });
 
 it('increments count', async () => {
   // Render new instance in every test to prevent leaking state
-  const { findByText } = renderComponent({ count: 5 });
+  const { getByText } = renderComponent({ count: 5 });
 
   fireEvent.click(getByText('+1'));
-  expect(await findByText(/clicked 6 times/i))
+  await waitForElement(() => getByText(/clicked 6 times/i));
 });


### PR DESCRIPTION
This reverts commit 46af15ad2d7311b57516e0c419badfe5648033ad in order to fix the broken build.